### PR TITLE
fix(chat): properly handle Korean IME input in message textarea

### DIFF
--- a/starting_point/frontend/components/chat.tsx
+++ b/starting_point/frontend/components/chat.tsx
@@ -15,6 +15,7 @@ interface ChatProps {
 const Chat: React.FC<ChatProps> = ({ items, onSendMessage, loading }) => {
   const itemsEndRef = useRef<HTMLDivElement>(null)
   const [inputMessageText, setinputMessageText] = useState<string>('')
+  const [composing, setComposing] = useState(false)
 
   const scrollToBottom = () => {
     itemsEndRef.current?.scrollIntoView({ behavior: 'instant' })
@@ -65,8 +66,10 @@ const Chat: React.FC<ChatProps> = ({ items, onSendMessage, loading }) => {
                       className="m-0 resize-none border-0 focus:outline-none text-sm bg-transparent px-0 py-2 max-h-[20dvh]"
                       value={inputMessageText}
                       onChange={e => setinputMessageText(e.target.value)}
+                      onCompositionStart={() => setComposing(true)}
+                      onCompositionEnd={() => setComposing(false)}
                       onKeyDown={e => {
-                        if (e.key === 'Enter' && !e.shiftKey) {
+                        if (!composing && e.key === 'Enter' && !e.shiftKey) {
                           e.preventDefault()
                           onSendMessage(inputMessageText)
                           setinputMessageText('')


### PR DESCRIPTION
This PR fixes an issue where pressing Enter while typing in Korean using an IME caused duplicate input or premature message submission.

### Changes
- Added `onCompositionStart` and `onCompositionEnd` to track IME composition.
- Ensured Enter does not trigger message submission while composing characters.
### Testing
- Verified correct handling of Korean IME input.
- Confirmed expected behavior for Enter and Shift+Enter.
### Before Fix

The screenshot below shows the issue where messages were being duplicated:
<img width="770" alt="스크린샷 2025-02-03 오후 7 19 18" src="https://github.com/user-attachments/assets/fcaf1539-06e7-4fa0-b550-abf0ad40d205" />
